### PR TITLE
feat: Add support for handling 'date' and 'external link page' mention objects

### DIFF
--- a/notion_graph/parser.py
+++ b/notion_graph/parser.py
@@ -288,14 +288,25 @@ class Parser:
                 "id": "960ce6bd-eeb8-4674-bf79-996ff40e14f8"
             }
         }
-        '''
-        block = self._notion.blocks.retrieve(
-            mention_obj[mention_obj['type']]['id'])
 
-        title = block[block['type']]['title']
-        print('Found mention node:', title)
-        self._graph.add_node(block['id'], title=title)
-        self._graph.add_edge(parent_page_or_database_id, block['id'])
+        {'type': 'date', 'date': {'start': '2022-11-25', 'end': None, 'time_zone': None}}
+        '''
+        try:
+            if mention_obj['type'] == 'page':
+                block = self._notion.blocks.retrieve(
+                    mention_obj[mention_obj['type']]['id'])
+
+                title = block[block['type']]['title']
+                print('Found mention node:', title)
+                self._graph.add_node(block['id'], title=title)
+                self._graph.add_edge(parent_page_or_database_id, block['id'])
+            elif mention_obj['type'] == 'date':
+                pass
+            else:
+                print(mention_obj)
+        except:
+            print('Found external link page: ', mention_obj)
+
 
     def _retrieve_page_or_database_title(self, page_or_database_id: str, parent_page_or_database_id: str):
         block = self._notion.blocks.retrieve(page_or_database_id)


### PR DESCRIPTION
This commit adds support for handling 'date' mention objects in the _retrieve_mention_object_title method. The method now includes a conditional branch to handle 'date' mention objects separately. If the mention object's type is 'date', the code currently does nothing (pass statement).

Additionally, a try-except block is introduced to catch any exceptions that might occur during the retrieval process. If an exception is raised, the code prints a message indicating that an external link page was found.

The commit also includes an updated code comment with an example of a 'date' mention object for reference.

Please review and merge these changes. Thanks